### PR TITLE
Adding GNOME 45.0 support

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,7 @@
 # Maintainer: Georg Wagner <puxplaying_at_gmail_dot_com>
 # Contributor: Mark Wagie <mark@manjaro.org>
 # Contributor: realqhc <https://github.com/realqhc>
+# Contributor: Brett Alcox <https://github.com/brettalcox>
 
 # Arch credits:
 # Maintainer: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
@@ -12,7 +13,7 @@
 
 pkgname=gnome-control-center-x11-scaling
 _pkgname=gnome-control-center
-pkgver=44.4
+pkgver=45.0
 pkgrel=1
 pkgdesc="GNOME's main interface to configure various aspects of the desktop with X11 fractional scaling patch"
 url="https://gitlab.gnome.org/GNOME/gnome-control-center"
@@ -73,18 +74,18 @@ optdepends=(
 groups=(gnome)
 conflicts=($_pkgname)
 provides=($_pkgname)
-_commit=abc71ea659f7c3efece766edb0365c78cc4b3df5  # tags/44.4^0
+_commit=e4d0d5abf9cb716cb01cda17751b162d4bfea5b0  # tags/45.0^0
 source=(
   "git+https://gitlab.gnome.org/GNOME/gnome-control-center.git#commit=$_commit"
   "git+https://gitlab.gnome.org/GNOME/libgnome-volume-control.git"
-  "display-Allow-fractional-scaling-to-be-enabled.patch::https://salsa.debian.org/gnome-team/gnome-control-center/-/raw/7da15e2567e77e1a589dc3135de2b4af119ecdde/debian/patches/ubuntu/display-Allow-fractional-scaling-to-be-enabled.patch"
-  "display-Support-UI-scaled-logical-monitor-mode.patch::https://salsa.debian.org/gnome-team/gnome-control-center/-/raw/40a04c330a95e178463371bf8570d8e6258dd906/debian/patches/ubuntu/display-Support-UI-scaled-logical-monitor-mode.patch"
-  "pixmaps-dir.diff::https://raw.githubusercontent.com/puxplaying/gnome-control-center-x11-scaling/8cafecb50c62f56dbe0a6cffb947b81aacbd4c41/pixmaps-dir.diff"
+  "gnome-control-center-45.0-display-Allow-fractional-scaling-to-be-enabled.patch"
+  "gnome-control-center-45.0-display-Support-UI-scaled-logical-monitor-mode.patch"
+  "pixmaps-dir.diff"
 )
 b2sums=('SKIP'
         'SKIP'
-        '828fd901dab24a9741989201f314514c2b19676ce43b7b4b474bf5e850ec84e7adf448ca08654b26b887ec3f7fb6089b41d67871bc5ce85281a57c784e31ead1'
-        'a7c10136b40ebd9e14eb21e3b1b65066d3e35524f7b1256f0a44094c39d8631ac8aa4e549e72cb096f43ac6f1e4853cc6935354b6c382989779189139be7d58f'
+        '968494b571fa09217b45ac94e02e931b0761a73cfcadde879d7a5d66f5ccd420d521b39d2eaf6dcfcf77ac7edbf3e7e3cabee54323ab641f2dbf6c6a04b122e3'
+        '7d0cd2fd2faa08ff5608b2e3965b6dafb829ff4de97c41b45a575126d926cb9c78197b0dc125e67d3007a5529559dbfba14039e64b658c788f7552af7c3146c1'
         '2a73d860ee17a40d847f9afc0e4be7f54b3bf8b67c133b6b61bffe83ca58de6542aea0ed96c8e4e104ee80e6089fb8c493048b95c6dae68f115826ce4984f315')
 
 pkgver() {
@@ -103,8 +104,8 @@ prepare() {
   git -c protocol.file.allow=always submodule update
 
   # Support UI scaled logical monitor mode (Marco Trevisan, Robert Ancell)
-  patch -p1 -i "${srcdir}/display-Support-UI-scaled-logical-monitor-mode.patch"
-  patch -p1 -i "${srcdir}/display-Allow-fractional-scaling-to-be-enabled.patch"
+  patch -p1 -i "${srcdir}/gnome-control-center-45.0-display-Support-UI-scaled-logical-monitor-mode.patch"
+  patch -p1 -i "${srcdir}/gnome-control-center-45.0-display-Allow-fractional-scaling-to-be-enabled.patch"
 }
 
 build() {

--- a/gnome-control-center-45.0-display-Allow-fractional-scaling-to-be-enabled.patch
+++ b/gnome-control-center-45.0-display-Allow-fractional-scaling-to-be-enabled.patch
@@ -1,0 +1,591 @@
+diff --git a/panels/display/cc-display-config-dbus.c b/panels/display/cc-display-config-dbus.c
+index 630309d2e..342cd0b5c 100644
+--- a/panels/display/cc-display-config-dbus.c
++++ b/panels/display/cc-display-config-dbus.c
+@@ -994,6 +994,8 @@ struct _CcDisplayConfigDBus
+   gboolean supports_changing_layout_mode;
+   gboolean global_scale_required;
+   CcDisplayLayoutMode layout_mode;
++  gint legacy_ui_scale;
++  char *renderer;
+ 
+   GList *monitors;
+   CcDisplayMonitorDBus *primary;
+@@ -1160,6 +1162,9 @@ cc_display_config_dbus_equal (CcDisplayConfig *pself,
+   g_return_val_if_fail (pself, FALSE);
+   g_return_val_if_fail (pother, FALSE);
+ 
++  if (self->layout_mode != other->layout_mode)
++    return FALSE;
++
+   cc_display_config_dbus_ensure_non_offset_coords (self);
+   cc_display_config_dbus_ensure_non_offset_coords (other);
+ 
+@@ -1463,6 +1468,29 @@ cc_display_config_dbus_is_layout_logical (CcDisplayConfig *pself)
+          self->layout_mode == CC_DISPLAY_LAYOUT_MODE_GLOBAL_UI_LOGICAL;
+ }
+ 
++static void
++cc_display_config_dbus_set_layout_logical (CcDisplayConfig *pself,
++                                           gboolean         logical)
++{
++  CcDisplayConfigDBus *self = CC_DISPLAY_CONFIG_DBUS (pself);
++
++  if (!self->supports_changing_layout_mode)
++    return;
++
++  if (!logical)
++    {
++      self->layout_mode = CC_DISPLAY_LAYOUT_MODE_PHYSICAL;
++      return;
++    }
++
++  if (g_str_equal (self->renderer, "native") || g_str_equal (self->renderer, "kms"))
++    self->layout_mode = CC_DISPLAY_LAYOUT_MODE_LOGICAL;
++  else if (g_str_equal (self->renderer, "xrandr"))
++    self->layout_mode = CC_DISPLAY_LAYOUT_MODE_GLOBAL_UI_LOGICAL;
++  else
++    g_return_if_reached ();
++}
++
+ static gboolean
+ cc_display_config_dbus_layout_use_ui_scale (CcDisplayConfig *pself)
+ {
+@@ -1470,6 +1498,20 @@ cc_display_config_dbus_layout_use_ui_scale (CcDisplayConfig *pself)
+   return self->layout_mode == CC_DISPLAY_LAYOUT_MODE_GLOBAL_UI_LOGICAL;
+ }
+ 
++static gint
++cc_display_config_dbus_get_legacy_ui_scale (CcDisplayConfig *pself)
++{
++  CcDisplayConfigDBus *self = CC_DISPLAY_CONFIG_DBUS (pself);
++  return self->legacy_ui_scale;
++}
++
++static const char *
++cc_display_config_dbus_get_renderer (CcDisplayConfig *pself)
++{
++  CcDisplayConfigDBus *self = CC_DISPLAY_CONFIG_DBUS (pself);
++  return self->renderer;
++}
++
+ static gboolean
+ is_scale_allowed_by_active_monitors (CcDisplayConfigDBus *self,
+                                      CcDisplayMode       *mode,
+@@ -1637,6 +1679,11 @@ cc_display_config_dbus_init (CcDisplayConfigDBus *self)
+   self->global_scale_required = FALSE;
+   self->layout_mode = CC_DISPLAY_LAYOUT_MODE_LOGICAL;
+   self->logical_monitors = g_hash_table_new (NULL, NULL);
++
++  if (g_getenv ("WAYLAND_DISPLAY"))
++    self->renderer = g_strdup ("native");
++  else if (g_getenv ("DISPLAY"))
++    self->renderer = g_strdup ("xrandr");
+ }
+ 
+ static void
+@@ -1822,6 +1869,15 @@ cc_display_config_dbus_constructed (GObject *object)
+         {
+           g_variant_get (v, "b", &self->global_scale_required);
+         }
++      else if (g_str_equal (s, "legacy-ui-scaling-factor"))
++        {
++          g_variant_get (v, "i", &self->legacy_ui_scale);
++        }
++      else if (g_str_equal (s, "renderer"))
++        {
++          g_clear_pointer (&self->renderer, g_free);
++          g_variant_get (v, "s", &self->renderer);
++        }
+       else if (g_str_equal (s, "layout-mode"))
+         {
+           guint32 u = 0;
+@@ -1925,6 +1981,7 @@ cc_display_config_dbus_finalize (GObject *object)
+ 
+   g_clear_list (&self->monitors, g_object_unref);
+   g_clear_pointer (&self->logical_monitors, g_hash_table_destroy);
++  g_clear_pointer (&self->renderer, g_free);
+ 
+   G_OBJECT_CLASS (cc_display_config_dbus_parent_class)->finalize (object);
+ }
+@@ -1950,11 +2007,14 @@ cc_display_config_dbus_class_init (CcDisplayConfigDBusClass *klass)
+   parent_class->set_cloning = cc_display_config_dbus_set_cloning;
+   parent_class->generate_cloning_modes = cc_display_config_dbus_generate_cloning_modes;
+   parent_class->is_layout_logical = cc_display_config_dbus_is_layout_logical;
++  parent_class->set_layout_logical = cc_display_config_dbus_set_layout_logical;
+   parent_class->is_scaled_mode_valid = cc_display_config_dbus_is_scaled_mode_valid;
+   parent_class->set_minimum_size = cc_display_config_dbus_set_minimum_size;
+   parent_class->get_panel_orientation_managed =
+     cc_display_config_dbus_get_panel_orientation_managed;
+   parent_class->layout_use_ui_scale = cc_display_config_dbus_layout_use_ui_scale;
++  parent_class->get_legacy_ui_scale = cc_display_config_dbus_get_legacy_ui_scale;
++  parent_class->get_renderer = cc_display_config_dbus_get_renderer;
+ 
+   pspec = g_param_spec_variant ("state",
+                                 "GVariant",
+diff --git a/panels/display/cc-display-config.c b/panels/display/cc-display-config.c
+index ff20495f2..ef4630252 100644
+--- a/panels/display/cc-display-config.c
++++ b/panels/display/cc-display-config.c
+@@ -17,6 +17,11 @@
+  *
+  */
+ 
++#define MUTTER_SCHEMA                     "org.gnome.mutter"
++#define MUTTER_EXPERIMENTAL_FEATURES_KEY  "experimental-features"
++#define MUTTER_FEATURE_FRACTIONAL_SCALING_X11 "x11-randr-fractional-scaling"
++#define MUTTER_FEATURE_FRACTIONAL_SCALING_WAYLAND "scale-monitor-framebuffer"
++
+ #include <gio/gio.h>
+ #include <math.h>
+ #include "cc-display-config.h"
+@@ -443,6 +448,10 @@ cc_display_monitor_set_ui_info (CcDisplayMonitor *self, gint ui_number, gchar *u
+ 
+ struct _CcDisplayConfigPrivate {
+   GList *ui_sorted_monitors;
++
++  GSettings *mutter_settings;
++  gboolean fractional_scaling;
++  gboolean fractional_scaling_pending_disable;
+ };
+ typedef struct _CcDisplayConfigPrivate CcDisplayConfigPrivate;
+ 
+@@ -450,6 +459,68 @@ G_DEFINE_TYPE_WITH_PRIVATE (CcDisplayConfig,
+                             cc_display_config,
+                             G_TYPE_OBJECT)
+ 
++static const char *
++get_fractional_scaling_key (CcDisplayConfig *self)
++{
++  const char *renderer = cc_display_config_get_renderer (self);
++
++  if (!renderer)
++    g_return_val_if_reached (MUTTER_FEATURE_FRACTIONAL_SCALING_WAYLAND);
++
++  if (g_str_equal (renderer, "xrandr"))
++    return MUTTER_FEATURE_FRACTIONAL_SCALING_X11;
++
++  if (g_str_equal (renderer, "native") || g_str_equal (renderer, "kms"))
++    return MUTTER_FEATURE_FRACTIONAL_SCALING_WAYLAND;
++
++  g_return_val_if_reached (NULL);
++}
++
++static gboolean
++get_fractional_scaling_active (CcDisplayConfig *self)
++{
++  const char *renderer = cc_display_config_get_renderer (self);
++
++  if (renderer && g_str_equal (renderer, "xrandr") &&
++      !cc_display_config_layout_use_ui_scale (self))
++    return FALSE;
++
++  return cc_display_config_is_layout_logical (self);
++}
++
++static void
++set_fractional_scaling_active (CcDisplayConfig *self,
++                               gboolean         enable)
++{
++  CcDisplayConfigPrivate *priv = cc_display_config_get_instance_private (self);
++  g_auto(GStrv) existing_features = NULL;
++  gboolean have_fractional_scaling = FALSE;
++  g_autoptr(GVariantBuilder) builder = NULL;
++  const char *key = get_fractional_scaling_key (self);
++
++  /* Add or remove the fractional scaling feature from mutter */
++  existing_features = g_settings_get_strv (priv->mutter_settings,
++                                           MUTTER_EXPERIMENTAL_FEATURES_KEY);
++  builder = g_variant_builder_new (G_VARIANT_TYPE ("as"));
++  for (int i = 0; existing_features[i] != NULL; i++)
++    {
++      if (g_strcmp0 (existing_features[i], key) == 0)
++        {
++          if (enable)
++            have_fractional_scaling = TRUE;
++          else
++            continue;
++        }
++
++      g_variant_builder_add (builder, "s", existing_features[i]);
++    }
++  if (enable && !have_fractional_scaling && key)
++    g_variant_builder_add (builder, "s", key);
++
++  g_settings_set_value (priv->mutter_settings, MUTTER_EXPERIMENTAL_FEATURES_KEY,
++                        g_variant_builder_end (builder));
++}
++
+ static void
+ cc_display_config_init (CcDisplayConfig *self)
+ {
+@@ -477,6 +548,10 @@ cc_display_config_constructed (GObject *object)
+     }
+ 
+   cc_display_config_update_ui_numbers_names(self);
++
++  /* No need to connect to the setting, as we'll get notified by mutter */
++  priv->mutter_settings = g_settings_new (MUTTER_SCHEMA);
++  priv->fractional_scaling = get_fractional_scaling_active (self);
+ }
+ 
+ static void
+@@ -486,6 +561,7 @@ cc_display_config_finalize (GObject *object)
+   CcDisplayConfigPrivate *priv = cc_display_config_get_instance_private (self);
+ 
+   g_list_free (priv->ui_sorted_monitors);
++  g_clear_object (&priv->mutter_settings);
+ 
+   G_OBJECT_CLASS (cc_display_config_parent_class)->finalize (object);
+ }
+@@ -577,9 +653,16 @@ gboolean
+ cc_display_config_equal (CcDisplayConfig *self,
+                          CcDisplayConfig *other)
+ {
++  CcDisplayConfigPrivate *spriv = cc_display_config_get_instance_private (self);
++  CcDisplayConfigPrivate *opriv = cc_display_config_get_instance_private (other);
++
+   g_return_val_if_fail (CC_IS_DISPLAY_CONFIG (self), FALSE);
+   g_return_val_if_fail (CC_IS_DISPLAY_CONFIG (other), FALSE);
+ 
++  if (spriv->fractional_scaling_pending_disable !=
++      opriv->fractional_scaling_pending_disable)
++    return FALSE;
++
+   return CC_DISPLAY_CONFIG_GET_CLASS (self)->equal (self, other);
+ }
+ 
+@@ -587,6 +670,8 @@ gboolean
+ cc_display_config_apply (CcDisplayConfig *self,
+                          GError **error)
+ {
++  CcDisplayConfigPrivate *priv = cc_display_config_get_instance_private (self);
++
+   if (!CC_IS_DISPLAY_CONFIG (self))
+     {
+       g_warning ("Cannot apply invalid configuration");
+@@ -597,6 +682,12 @@ cc_display_config_apply (CcDisplayConfig *self,
+       return FALSE;
+     }
+ 
++  if (priv->fractional_scaling_pending_disable)
++    {
++      set_fractional_scaling_active (self, FALSE);
++      priv->fractional_scaling_pending_disable = FALSE;
++    }
++
+   return CC_DISPLAY_CONFIG_GET_CLASS (self)->apply (self, error);
+ }
+ 
+@@ -629,6 +720,14 @@ cc_display_config_is_layout_logical (CcDisplayConfig *self)
+   return CC_DISPLAY_CONFIG_GET_CLASS (self)->is_layout_logical (self);
+ }
+ 
++void
++cc_display_config_set_layout_logical (CcDisplayConfig *self,
++                                      gboolean         logical)
++{
++  g_return_if_fail (CC_IS_DISPLAY_CONFIG (self));
++  return CC_DISPLAY_CONFIG_GET_CLASS (self)->set_layout_logical (self, logical);
++}
++
+ void
+ cc_display_config_set_minimum_size (CcDisplayConfig *self,
+                                     int              width,
+@@ -638,13 +737,37 @@ cc_display_config_set_minimum_size (CcDisplayConfig *self,
+   CC_DISPLAY_CONFIG_GET_CLASS (self)->set_minimum_size (self, width, height);
+ }
+ 
++gint
++cc_display_config_get_legacy_ui_scale (CcDisplayConfig *self)
++{
++  return CC_DISPLAY_CONFIG_GET_CLASS (self)->get_legacy_ui_scale (self);
++}
++
++const char *
++cc_display_config_get_renderer (CcDisplayConfig *self)
++{
++  return CC_DISPLAY_CONFIG_GET_CLASS (self)->get_renderer (self);
++}
++
++static gboolean
++scale_value_is_fractional (double scale)
++{
++  return (int) scale != scale;
++}
++
+ gboolean
+ cc_display_config_is_scaled_mode_valid (CcDisplayConfig *self,
+                                         CcDisplayMode   *mode,
+                                         double           scale)
+ {
++  CcDisplayConfigPrivate *priv = cc_display_config_get_instance_private (self);
++
+   g_return_val_if_fail (CC_IS_DISPLAY_CONFIG (self), FALSE);
+   g_return_val_if_fail (CC_IS_DISPLAY_MODE (mode), FALSE);
++
++  if (priv->fractional_scaling_pending_disable && scale_value_is_fractional (scale))
++    return FALSE;
++
+   return CC_DISPLAY_CONFIG_GET_CLASS (self)->is_scaled_mode_valid (self, mode, scale);
+ }
+ 
+@@ -706,3 +829,124 @@ cc_display_config_get_maximum_scaling (CcDisplayConfig *self)
+ 
+   return max_scale;
+ }
++
++static gboolean
++set_monitors_scaling_to_preferred_integers (CcDisplayConfig *self)
++{
++  GList *l;
++  gboolean any_changed = FALSE;
++
++  for (l = cc_display_config_get_monitors (self); l; l = l->next)
++    {
++      CcDisplayMonitor *monitor = l->data;
++      gdouble monitor_scale = cc_display_monitor_get_scale (monitor);
++
++      if (scale_value_is_fractional (monitor_scale))
++        {
++          CcDisplayMode *preferred_mode;
++          double preferred_scale;
++          double *saved_scale;
++
++          preferred_mode = cc_display_monitor_get_preferred_mode (monitor);
++          preferred_scale = cc_display_mode_get_preferred_scale (preferred_mode);
++          cc_display_monitor_set_scale (monitor, preferred_scale);
++          any_changed = TRUE;
++
++          saved_scale = g_new (double, 1);
++          *saved_scale = monitor_scale;
++          g_object_set_data_full (G_OBJECT (monitor),
++                                  "previous-fractional-scale",
++                                  saved_scale, g_free);
++        }
++      else
++        {
++          g_signal_emit_by_name (monitor, "scale");
++        }
++    }
++
++  return any_changed;
++}
++
++static void
++reset_monitors_scaling_to_selected_values (CcDisplayConfig *self)
++{
++  GList *l;
++
++  for (l = cc_display_config_get_monitors (self); l; l = l->next)
++    {
++      CcDisplayMonitor *monitor = l->data;
++      gdouble *saved_scale;
++
++      saved_scale = g_object_get_data (G_OBJECT (monitor),
++                                       "previous-fractional-scale");
++
++      if (saved_scale)
++        {
++          cc_display_monitor_set_scale (monitor, *saved_scale);
++          g_object_set_data (G_OBJECT (monitor), "previous-fractional-scale", NULL);
++        }
++      else
++        {
++          g_signal_emit_by_name (monitor, "scale");
++        }
++    }
++}
++
++void
++cc_display_config_set_fractional_scaling (CcDisplayConfig *self,
++                                          gboolean         enabled)
++{
++  CcDisplayConfigPrivate *priv = cc_display_config_get_instance_private (self);
++
++  if (priv->fractional_scaling == enabled)
++    return;
++
++  priv->fractional_scaling = enabled;
++
++  if (!cc_display_config_layout_use_ui_scale (self))
++    cc_display_config_set_layout_logical (self, enabled);
++
++  if (priv->fractional_scaling)
++    {
++      if (priv->fractional_scaling_pending_disable)
++        {
++          priv->fractional_scaling_pending_disable = FALSE;
++          reset_monitors_scaling_to_selected_values (self);
++        }
++
++      if (!get_fractional_scaling_active (self))
++        set_fractional_scaling_active (self, enabled);
++    }
++  else
++    {
++      priv->fractional_scaling_pending_disable = TRUE;
++
++      if (!set_monitors_scaling_to_preferred_integers (self))
++        {
++          gboolean disable_now = FALSE;
++
++          if (cc_display_config_layout_use_ui_scale (self))
++            {
++              disable_now =
++                G_APPROX_VALUE (cc_display_config_get_legacy_ui_scale (self),
++                                cc_display_config_get_maximum_scaling (self),
++                                DBL_EPSILON);
++            }
++
++          if (disable_now)
++            {
++              priv->fractional_scaling_pending_disable = FALSE;
++              reset_monitors_scaling_to_selected_values (self);
++              set_fractional_scaling_active (self, enabled);
++            }
++        }
++    }
++}
++
++gboolean
++cc_display_config_get_fractional_scaling (CcDisplayConfig *self)
++{
++  CcDisplayConfigPrivate *priv = cc_display_config_get_instance_private (self);
++
++  return priv->fractional_scaling;
++}
+diff --git a/panels/display/cc-display-config.h b/panels/display/cc-display-config.h
+index 4c0011928..145399be1 100644
+--- a/panels/display/cc-display-config.h
++++ b/panels/display/cc-display-config.h
+@@ -167,6 +167,8 @@ struct _CcDisplayConfigClass
+                                  gboolean          clone);
+   GList*   (*generate_cloning_modes) (CcDisplayConfig  *self);
+   gboolean (*is_layout_logical) (CcDisplayConfig  *self);
++  void     (*set_layout_logical) (CcDisplayConfig  *self,
++                                 gboolean          enabled);
+   void     (*set_minimum_size)  (CcDisplayConfig  *self,
+                                  int               width,
+                                  int               height);
+@@ -175,6 +177,8 @@ struct _CcDisplayConfigClass
+                                     double            scale);
+   gboolean (* get_panel_orientation_managed) (CcDisplayConfig    *self);
+   gboolean (*layout_use_ui_scale) (CcDisplayConfig  *self);
++  gint     (*get_legacy_ui_scale) (CcDisplayConfig  *self);
++  const char * (*get_renderer)    (CcDisplayConfig  *self);
+ };
+ 
+ 
+@@ -195,6 +199,8 @@ void              cc_display_config_set_mode_on_all_outputs (CcDisplayConfig *co
+                                                              CcDisplayMode   *mode);
+ 
+ gboolean          cc_display_config_is_layout_logical       (CcDisplayConfig    *self);
++void              cc_display_config_set_layout_logical      (CcDisplayConfig    *self,
++                                                             gboolean            logical);
+ void              cc_display_config_set_minimum_size        (CcDisplayConfig    *self,
+                                                              int                 width,
+                                                              int                 height);
+@@ -205,8 +211,13 @@ gboolean          cc_display_config_get_panel_orientation_managed
+                                                             (CcDisplayConfig    *self);
+ void              cc_display_config_update_ui_numbers_names (CcDisplayConfig    *self);
+ gboolean          cc_display_config_layout_use_ui_scale     (CcDisplayConfig    *self);
++gint              cc_display_config_get_legacy_ui_scale     (CcDisplayConfig    *self);
++const char*       cc_display_config_get_renderer            (CcDisplayConfig    *self);
+ 
+ double            cc_display_config_get_maximum_scaling     (CcDisplayConfig    *self);
++void              cc_display_config_set_fractional_scaling  (CcDisplayConfig    *self,
++                                                             gboolean            enabled);
++gboolean          cc_display_config_get_fractional_scaling  (CcDisplayConfig    *self);
+ 
+ const char*       cc_display_monitor_get_display_name       (CcDisplayMonitor   *monitor);
+ gboolean          cc_display_monitor_is_active              (CcDisplayMonitor   *monitor);
+diff --git a/panels/display/cc-display-settings.c b/panels/display/cc-display-settings.c
+index 9d67a2ec8..5bcf925cf 100644
+--- a/panels/display/cc-display-settings.c
++++ b/panels/display/cc-display-settings.c
+@@ -55,6 +55,7 @@ struct _CcDisplaySettings
+   GtkWidget        *scale_bbox;
+   GtkWidget        *scale_buttons_row;
+   GtkWidget        *scale_combo_row;
++  GtkWidget        *scale_fractional_row;
+   GtkWidget        *underscanning_row;
+   GtkWidget        *underscanning_switch;
+ };
+@@ -256,6 +257,7 @@ cc_display_settings_rebuild_ui (CcDisplaySettings *self)
+       gtk_widget_set_visible (self->resolution_row, FALSE);
+       gtk_widget_set_visible (self->scale_combo_row, FALSE);
+       gtk_widget_set_visible (self->scale_buttons_row, FALSE);
++      gtk_widget_set_visible (self->scale_fractional_row, FALSE);
+       gtk_widget_set_visible (self->underscanning_row, FALSE);
+ 
+       return G_SOURCE_REMOVE;
+@@ -464,6 +466,11 @@ cc_display_settings_rebuild_ui (CcDisplaySettings *self)
+     }
+   cc_display_settings_refresh_layout (self, self->collapsed);
+ 
++  gtk_widget_set_visible (self->scale_fractional_row, TRUE);
++  g_object_set (G_OBJECT (self->scale_fractional_row), "active",
++                cc_display_config_get_fractional_scaling (self->config),
++                NULL);
++
+   gtk_widget_set_visible (self->underscanning_row,
+                           cc_display_monitor_supports_underscanning (self->selected_output) &&
+                           !cc_display_config_is_cloning (self->config));
+@@ -747,6 +754,7 @@ cc_display_settings_class_init (CcDisplaySettingsClass *klass)
+   gtk_widget_class_bind_template_child (widget_class, CcDisplaySettings, scale_bbox);
+   gtk_widget_class_bind_template_child (widget_class, CcDisplaySettings, scale_buttons_row);
+   gtk_widget_class_bind_template_child (widget_class, CcDisplaySettings, scale_combo_row);
++  gtk_widget_class_bind_template_child (widget_class, CcDisplaySettings, scale_fractional_row);
+   gtk_widget_class_bind_template_child (widget_class, CcDisplaySettings, underscanning_row);
+   gtk_widget_class_bind_template_child (widget_class, CcDisplaySettings, underscanning_switch);
+ 
+@@ -758,6 +766,19 @@ cc_display_settings_class_init (CcDisplaySettingsClass *klass)
+   gtk_widget_class_bind_template_callback (widget_class, on_underscanning_switch_active_changed_cb);
+ }
+ 
++static void
++on_scale_fractional_toggled (CcDisplaySettings *self)
++{
++  gboolean active;
++
++  active = adw_switch_row_get_active (self->scale_fractional_row);
++
++  if (self->config)
++    cc_display_config_set_fractional_scaling (self->config, active);
++
++  g_signal_emit_by_name (G_OBJECT (self), "updated", self->selected_output);
++}
++
+ static void
+ cc_display_settings_init (CcDisplaySettings *self)
+ {
+@@ -793,6 +814,11 @@ cc_display_settings_init (CcDisplaySettings *self)
+   adw_combo_row_set_model (ADW_COMBO_ROW (self->resolution_row),
+                            G_LIST_MODEL (self->resolution_list));
+ 
++  g_signal_connect_object (self->scale_fractional_row,
++                           "notify::active",
++                           G_CALLBACK (on_scale_fractional_toggled),
++                           self, G_CONNECT_SWAPPED);
++
+   self->updating = FALSE;
+ }
+ 
+diff --git a/panels/display/cc-display-settings.ui b/panels/display/cc-display-settings.ui
+index 6de2ba6ee..dec9f5286 100644
+--- a/panels/display/cc-display-settings.ui
++++ b/panels/display/cc-display-settings.ui
+@@ -95,6 +95,12 @@
+             <signal name="notify::selected-item" handler="on_scale_selection_changed_cb" swapped="yes"/>
+           </object>
+         </child>
++        <child>
++          <object class="AdwSwitchRow" id="scale_fractional_row">
++            <property name="title" translatable="yes" context="display setting">Fractional Scaling</property>
++            <property name="subtitle" translatable="yes" context="display setting">May increase power usage, lower speed, or reduce display sharpness.</property>
++          </object>
++        </child>
+       </object>
+     </child>
+   </template>

--- a/gnome-control-center-45.0-display-Support-UI-scaled-logical-monitor-mode.patch
+++ b/gnome-control-center-45.0-display-Support-UI-scaled-logical-monitor-mode.patch
@@ -1,0 +1,250 @@
+diff --git a/panels/display/cc-display-arrangement.c b/panels/display/cc-display-arrangement.c
+index a55aa6a21..3b755d70e 100644
+--- a/panels/display/cc-display-arrangement.c
++++ b/panels/display/cc-display-arrangement.c
+@@ -99,6 +99,7 @@ apply_rotation_to_geometry (CcDisplayMonitor *output,
+ static void
+ get_scaled_geometry (CcDisplayConfig  *config,
+                      CcDisplayMonitor *output,
++                     double            max_scale,
+                      int              *x,
+                      int              *y,
+                      int              *w,
+@@ -117,6 +118,10 @@ get_scaled_geometry (CcDisplayConfig  *config,
+   if (cc_display_config_is_layout_logical (config))
+     {
+       double scale = cc_display_monitor_get_scale (output);
++
++      if (cc_display_config_layout_use_ui_scale (config))
++        scale /= ceil (max_scale);
++
+       *w = round (*w / scale);
+       *h = round (*h / scale);
+     }
+@@ -134,6 +139,7 @@ get_bounding_box (CcDisplayConfig *config,
+                   gint            *max_h)
+ {
+   GList *outputs, *l;
++  gdouble max_scale;
+ 
+   g_assert (x1 && y1 && x2 && y2);
+ 
+@@ -141,6 +147,7 @@ get_bounding_box (CcDisplayConfig *config,
+   *x2 = *y2 = G_MININT;
+   *max_w = 0;
+   *max_h = 0;
++  max_scale = cc_display_config_get_maximum_scaling (config);
+ 
+   outputs = cc_display_config_get_monitors (config);
+   for (l = outputs; l; l = l->next)
+@@ -151,7 +158,7 @@ get_bounding_box (CcDisplayConfig *config,
+       if (!cc_display_monitor_is_useful (output))
+         continue;
+ 
+-      get_scaled_geometry (config, output, &x, &y, &w, &h);
++      get_scaled_geometry (config, output, max_scale, &x, &y, &w, &h);
+ 
+       *x1 = MIN (*x1, x);
+       *y1 = MIN (*y1, y);
+@@ -171,8 +178,10 @@ monitor_get_drawing_rect (CcDisplayArrangement *self,
+                           gint                 *y2)
+ {
+   gdouble x, y;
++  gdouble max_scale;
+ 
+-  get_scaled_geometry (self->config, output, x1, y1, x2, y2);
++  max_scale = cc_display_config_get_maximum_scaling (self->config);
++  get_scaled_geometry (self->config, output, max_scale, x1, y1, x2, y2);
+ 
+   /* get_scaled_geometry returns the width and height */
+   *x2 = *x1 + *x2;
+@@ -325,10 +334,12 @@ find_best_snapping (CcDisplayConfig   *config,
+   GList *outputs, *l;
+   gint x1, y1, x2, y2;
+   gint w, h;
++  double max_scale;
+ 
+   g_assert (snap_data != NULL);
+ 
+-  get_scaled_geometry (config, snap_output, &x1, &y1, &w, &h);
++  max_scale = cc_display_config_get_maximum_scaling (config);
++  get_scaled_geometry (config, snap_output, max_scale, &x1, &y1, &w, &h);
+   x2 = x1 + w;
+   y2 = y1 + h;
+ 
+@@ -344,6 +355,7 @@ find_best_snapping (CcDisplayConfig   *config,
+       gint left_snap_pos;
+       gint right_snap_pos;
+       gdouble dist_x, dist_y;
++      gdouble max_scale;
+       gdouble tmp;
+ 
+       if (output == snap_output)
+@@ -352,7 +364,8 @@ find_best_snapping (CcDisplayConfig   *config,
+       if (!cc_display_monitor_is_useful (output))
+         continue;
+ 
+-      get_scaled_geometry (config, output, &_x1, &_y1, &_w, &_h);
++      max_scale = cc_display_config_get_maximum_scaling (config);
++      get_scaled_geometry (config, output, max_scale, &_x1, &_y1, &_w, &_h);
+       _x2 = _x1 + _w;
+       _y2 = _y1 + _h;
+ 
+@@ -952,11 +965,13 @@ try_snap_output (CcDisplayConfig  *config,
+ {
+   SnapData snap_data;
+   gint x, y, w, h;
++  gdouble max_scale;
+ 
+   if (!cc_display_monitor_is_useful (output))
+     return FALSE;
+ 
+-  get_scaled_geometry (config, output, &x, &y, &w, &h);
++  max_scale = cc_display_config_get_maximum_scaling (config);
++  get_scaled_geometry (config, output, max_scale, &x, &y, &w, &h);
+ 
+   snap_data.snapped = SNAP_DIR_NONE;
+   snap_data.mon_x = x;
+diff --git a/panels/display/cc-display-config-dbus.c b/panels/display/cc-display-config-dbus.c
+index 7b454955e..630309d2e 100644
+--- a/panels/display/cc-display-config-dbus.c
++++ b/panels/display/cc-display-config-dbus.c
+@@ -965,7 +965,8 @@ cc_display_monitor_dbus_new (GVariant *variant,
+ typedef enum _CcDisplayLayoutMode
+ {
+   CC_DISPLAY_LAYOUT_MODE_LOGICAL = 1,
+-  CC_DISPLAY_LAYOUT_MODE_PHYSICAL = 2
++  CC_DISPLAY_LAYOUT_MODE_PHYSICAL = 2,
++  CC_DISPLAY_LAYOUT_MODE_GLOBAL_UI_LOGICAL = 3
+ } CcDisplayLayoutMode;
+ 
+ typedef enum _CcDisplayConfigMethod
+@@ -1458,7 +1459,15 @@ cc_display_config_dbus_is_layout_logical (CcDisplayConfig *pself)
+ {
+   CcDisplayConfigDBus *self = CC_DISPLAY_CONFIG_DBUS (pself);
+ 
+-  return self->layout_mode == CC_DISPLAY_LAYOUT_MODE_LOGICAL;
++  return self->layout_mode == CC_DISPLAY_LAYOUT_MODE_LOGICAL ||
++         self->layout_mode == CC_DISPLAY_LAYOUT_MODE_GLOBAL_UI_LOGICAL;
++}
++
++static gboolean
++cc_display_config_dbus_layout_use_ui_scale (CcDisplayConfig *pself)
++{
++  CcDisplayConfigDBus *self = CC_DISPLAY_CONFIG_DBUS (pself);
++  return self->layout_mode == CC_DISPLAY_LAYOUT_MODE_GLOBAL_UI_LOGICAL;
+ }
+ 
+ static gboolean
+@@ -1818,7 +1827,7 @@ cc_display_config_dbus_constructed (GObject *object)
+           guint32 u = 0;
+           g_variant_get (v, "u", &u);
+           if (u >= CC_DISPLAY_LAYOUT_MODE_LOGICAL &&
+-              u <= CC_DISPLAY_LAYOUT_MODE_PHYSICAL)
++              u <= CC_DISPLAY_LAYOUT_MODE_GLOBAL_UI_LOGICAL)
+             self->layout_mode = u;
+         }
+     }
+@@ -1945,6 +1954,7 @@ cc_display_config_dbus_class_init (CcDisplayConfigDBusClass *klass)
+   parent_class->set_minimum_size = cc_display_config_dbus_set_minimum_size;
+   parent_class->get_panel_orientation_managed =
+     cc_display_config_dbus_get_panel_orientation_managed;
++  parent_class->layout_use_ui_scale = cc_display_config_dbus_layout_use_ui_scale;
+ 
+   pspec = g_param_spec_variant ("state",
+                                 "GVariant",
+@@ -2005,6 +2015,26 @@ logical_monitor_is_rotated (CcDisplayLogicalMonitor *lm)
+     }
+ }
+ 
++static double
++get_maximum_scale (CcDisplayConfig *config)
++{
++  GList *outputs, *l;
++  double max_scale = 1.0;
++  outputs = cc_display_config_get_monitors (config);
++
++  for (l = outputs; l; l = l->next)
++    {
++      CcDisplayMonitor *output = l->data;
++
++      if (!cc_display_monitor_is_useful (output))
++        continue;
++
++      max_scale = MAX (max_scale, cc_display_monitor_get_scale (output));
++    }
++
++  return max_scale;
++}
++
+ static int
+ logical_monitor_width (CcDisplayLogicalMonitor *lm)
+ {
+@@ -2023,6 +2053,11 @@ logical_monitor_width (CcDisplayLogicalMonitor *lm)
+ 
+   if (monitor->config->layout_mode == CC_DISPLAY_LAYOUT_MODE_LOGICAL)
+     return round (width / lm->scale);
++  if (monitor->config->layout_mode == CC_DISPLAY_LAYOUT_MODE_GLOBAL_UI_LOGICAL)
++    {
++      double max_scale = get_maximum_scale(CC_DISPLAY_CONFIG (monitor->config));
++      return round ((width * ceil (max_scale)) / lm->scale);
++    }
+   else
+     return width;
+ }
+diff --git a/panels/display/cc-display-config.c b/panels/display/cc-display-config.c
+index f2ccda522..ff20495f2 100644
+--- a/panels/display/cc-display-config.c
++++ b/panels/display/cc-display-config.c
+@@ -680,3 +680,29 @@ cc_display_config_update_ui_numbers_names (CcDisplayConfig *self)
+       cc_display_monitor_set_ui_info (monitor, current_ui_number, ui_name);
+     }
+ }
++
++gboolean
++cc_display_config_layout_use_ui_scale (CcDisplayConfig *self)
++{
++  return CC_DISPLAY_CONFIG_GET_CLASS (self)->layout_use_ui_scale (self);
++}
++
++double
++cc_display_config_get_maximum_scaling (CcDisplayConfig *self)
++{
++  GList *outputs, *l;
++  double max_scale = 1.0;
++  outputs = cc_display_config_get_monitors (self);
++
++  for (l = outputs; l; l = l->next)
++    {
++      CcDisplayMonitor *output = l->data;
++
++      if (!cc_display_monitor_is_useful (output))
++        continue;
++
++      max_scale = MAX (max_scale, cc_display_monitor_get_scale (output));
++    }
++
++  return max_scale;
++}
+diff --git a/panels/display/cc-display-config.h b/panels/display/cc-display-config.h
+index ea52c2d59..4c0011928 100644
+--- a/panels/display/cc-display-config.h
++++ b/panels/display/cc-display-config.h
+@@ -174,6 +174,7 @@ struct _CcDisplayConfigClass
+                                     CcDisplayMode    *mode,
+                                     double            scale);
+   gboolean (* get_panel_orientation_managed) (CcDisplayConfig    *self);
++  gboolean (*layout_use_ui_scale) (CcDisplayConfig  *self);
+ };
+ 
+ 
+@@ -203,6 +204,9 @@ gboolean          cc_display_config_is_scaled_mode_valid    (CcDisplayConfig
+ gboolean          cc_display_config_get_panel_orientation_managed
+                                                             (CcDisplayConfig    *self);
+ void              cc_display_config_update_ui_numbers_names (CcDisplayConfig    *self);
++gboolean          cc_display_config_layout_use_ui_scale     (CcDisplayConfig    *self);
++
++double            cc_display_config_get_maximum_scaling     (CcDisplayConfig    *self);
+ 
+ const char*       cc_display_monitor_get_display_name       (CcDisplayMonitor   *monitor);
+ gboolean          cc_display_monitor_is_active              (CcDisplayMonitor   *monitor);


### PR DESCRIPTION
Follow up PR to the one opened on mutter-x11-scaling for GNOME 45.0. Patches again no longer cleanly apply and required some manual intervention. Additionally, moved the patch referencing to local reference rather than HTTPS download, as to not depend on a mirror not under our control. Installed both the 45.0 version of mutter-x11-scaling and gnome-control-center-x11-scaling on my Arch install running GNOME 45.0 and it works as expected :D 

![Screenshot from 2023-09-25 17-47-18](https://github.com/puxplaying/gnome-control-center-x11-scaling/assets/7462622/8eb80607-bf8d-4b03-ac21-59b3d08fdb57)
